### PR TITLE
fix(onManifest): Remove `version` in `onManifest`

### DIFF
--- a/src/generator/prisma-appsync.ts
+++ b/src/generator/prisma-appsync.ts
@@ -3,9 +3,6 @@ import { PrismaAppSyncCompiler } from './compiler'
 import { generatorHandler } from '@prisma/generator-helper'
 import { parseEnvValue } from '@prisma/sdk'
 
-// Read Prisma AppSync version
-const generatorVersion = require('../../package.json').version
-
 // Prisma AppSync Generator Handler
 generatorHandler({
     onManifest() {
@@ -13,7 +10,6 @@ generatorHandler({
             defaultOutput: 'generated/prisma-appsync',
             prettyName: 'Prisma-AppSync',
             requiresEngines: ['queryEngine'],
-            version: generatorVersion,
         }
     },
     async onGenerate(options:any) {


### PR DESCRIPTION
The `version` in `onManifest()` is pretty badly defined right now and not used for anything, so it might be better to get rid of it as we might need to redefine its behavior in the future.