### PR TITLE
fix(compiler): graphql schema's relation values are not PascalCase

### DIFF
--- a/src/generator/compiler.ts
+++ b/src/generator/compiler.ts
@@ -483,7 +483,7 @@ export class PrismaAppSyncCompiler {
                 }
             }
         } else {
-            type = field.type
+            type = pascalCase(field.type)
         }
         
         return type

--- a/src/generator/compiler.ts
+++ b/src/generator/compiler.ts
@@ -482,10 +482,12 @@ export class PrismaAppSyncCompiler {
                     case 'url': type = 'AWSURL'; break
                 }
             }
+        } else if (field.kind === 'enum') {
+            type = field.type
         } else {
             type = pascalCase(field.type)
         }
-        
+
         return type
     }
 

--- a/src/generator/compiler.ts
+++ b/src/generator/compiler.ts
@@ -482,10 +482,10 @@ export class PrismaAppSyncCompiler {
                     case 'url': type = 'AWSURL'; break
                 }
             }
-        } else if (field.kind === 'enum') {
-            type = field.type
+        } else if (this.isFieldEnum(field)) {
+            type = field.type;
         } else {
-            type = pascalCase(field.type)
+            type = pascalCase(field.type);
         }
 
         return type


### PR DESCRIPTION
## Summary

This PR fixes an issue in the generated GraphQL schema where relation definitions were using the incorrect case for type values. 

This resulted in errors such as:
```sh
Unknown type "github_issue_labels_v3CreateInput". Did you mean "GithubIssueLabelsV3CreateInput", "GithubIssueLabelsV3UpdateInput", "GithubIssueLabelsV3CreateManyInput", "GithubIssueLabelsV3OrderByInput", or "GithubIssueLabelsV3UpsertInput"?
```
Where `GithubIssueLabelsV3CreateInput` was in fact the intended value.

This change converts the type values to PascalCase.

fixes: https://github.com/maoosi/prisma-appsync/issues/39