### PR TITLE
Fixed hooks

### DIFF
--- a/packages/client/src/core.ts
+++ b/packages/client/src/core.ts
@@ -1,5 +1,4 @@
 import type {
-    AfterHookParams,
     InjectedConfig,
     Options,
     Prisma,
@@ -418,14 +417,13 @@ export class PrismaAppSync {
 
             // Guard: get and run all after hooks functions matching query
             if (resolveParams?.hooks) {
-                const q: AfterHookParams = await runHooks({
+                result = await runHooks({
                     when: 'after',
                     hooks: resolveParams.hooks,
                     prismaClient: this.prismaClient,
                     QueryParams,
                     result,
                 })
-                result = q.result
             }
         }
         catch (error) {

--- a/packages/client/src/guard.ts
+++ b/packages/client/src/guard.ts
@@ -237,7 +237,7 @@ export async function runHooks({
         }
     }
 
-    return result
+    return result || QueryParams
 }
 
 export async function preventDOS({


### PR DESCRIPTION
The problem that happens for me is that when `runHooks` is first called, the result is undefined and that is being returned from the function on an operation that doesn't have a hook.

Eg: you define a hook for `before:listPosts` but you make a query for `listUsers`

In that instance, result will be undefined and that is what will override QueryParams on line 326 in core.ts hence the `result || QueryParams` on line 240 of guard.ts

Now, if you have an `after:listPosts` hook that is simply a nop
```
"after:listPosts": async (props): Promise<AfterHookParams> => {
            return props
          }
``` 
The result from `runHooks` is going to be the same props that were passed as params and the result will be the same. `q.result` would simply be undefined therefore I am directly assigning the output from `runHooks` to result