### PR TITLE
Initialize prismaArgs with empty select

### DIFF
--- a/packages/client/src/adapter.ts
+++ b/packages/client/src/adapter.ts
@@ -488,7 +488,7 @@ function getSelect(parts: any): any {
  * @returns any
  */
 function parseSelectionList(selectionSetList: any): any {
-    let prismaArgs: any = {}
+    let prismaArgs: any = { select: {} }
 
     for (let i = 0; i < selectionSetList.length; i++) {
         const path = selectionSetList[i]


### PR DESCRIPTION
When using a custom resolver with some selected properties this method would fail with 
`10:38:48 0|prisma-appsync--server  | ◭ 01/12/2022, 10:38:48 <<ERROR>> Cannot read properties of undefined (reading 'selectedQueryProperty')`

This happens because select is undefined here
```
if (typeof prismaArgs.select[include] !== 'undefined')
                delete prismaArgs.select[include]
```
