### PR TITLE
Feat: Support for deeply nested relation filters + Issue: GraphQL input `<Model>WhereUniqueInput` shouldn’t include Relation fields

### DIFF
--- a/packages/boilerplate/prisma/postgres.prisma
+++ b/packages/boilerplate/prisma/postgres.prisma
@@ -16,7 +16,7 @@ model User {
     id        Int       @id @default(autoincrement())
     createdAt DateTime  @default(now())
     email     String    @unique
-    name      String?
+    username  String?
     role      Role?     @default(USER)
     posts     Post[]
     comments  Comment[]
@@ -49,7 +49,7 @@ enum Category {
 
 model Comment {
     id        Int      @id @default(autoincrement())
-    text      String
+    message   String
     author    User     @relation(fields: [authorId], references: [id])
     authorId  Int
     post      Post     @relation(fields: [postId], references: [id])

--- a/packages/generator/src/compiler.ts
+++ b/packages/generator/src/compiler.ts
@@ -827,7 +827,6 @@ export class PrismaAppSyncCompiler {
 
     // Return relation kind (`one` or `many`) from Prisma type
     private getFieldRelationKind(field: DMMF.Field): 'one' | 'many' {
-        // return field.relationFromFields && field.relationFromFields.length === 1 ? 'one' : 'many'
         return !field.isList ? 'one' : 'many'
     }
 

--- a/packages/generator/src/compiler.ts
+++ b/packages/generator/src/compiler.ts
@@ -552,7 +552,7 @@ export class PrismaAppSyncCompiler {
                             isList: this.isFieldList(field),
                             isEnum: this.isFieldEnum(field),
                             isEditable: !this.isFieldGeneratedRelation(field, model),
-                            isUnique: this.isFieldUnique(field, model),
+                            isUnique: this.isFieldUnique(field),
                             ...(field.relationName && {
                                 relation: {
                                     name: this.getFieldRelationName(field, model),
@@ -685,8 +685,8 @@ export class PrismaAppSyncCompiler {
     }
 
     // Return true if field is unique (meaning it can be used for WhereUniqueInputs)
-    private isFieldUnique(searchField: DMMF.Field, model: DMMF.Model): boolean {
-        return searchField.isId || searchField.isUnique || this.isFieldGeneratedRelation(searchField, model)
+    private isFieldUnique(searchField: DMMF.Field): boolean {
+        return searchField.isId || searchField.isUnique
     }
 
     // Return true if field is required
@@ -827,7 +827,7 @@ export class PrismaAppSyncCompiler {
 
     // Return relation kind (`one` or `many`) from Prisma type
     private getFieldRelationKind(field: DMMF.Field): 'one' | 'many' {
-        return field.relationFromFields && field.relationFromFields.length === 1 ? 'one' : 'many'
+        return !field.isList ? 'one' : 'many'
     }
 
     // Get AppSync scalar from Prisma type

--- a/packages/generator/src/compiler.ts
+++ b/packages/generator/src/compiler.ts
@@ -748,27 +748,27 @@ export class PrismaAppSyncCompiler {
         let parserOpt: prettier.RequiredOptions['parser'] | boolean
 
         switch (extname(outputFilename)) {
-        case '.ts':
-            parserOpt = 'typescript'
-            break
-        case '.json':
-            parserOpt = 'json'
-            break
-        case '.gql':
-            parserOpt = 'graphql'
-            break
-        case '.md':
-            parserOpt = 'markdown'
-            break
-        case '.yaml':
-            parserOpt = 'yaml'
-            break
-        case '.js':
-            parserOpt = 'babel'
-            break
-        default:
-            parserOpt = false
-            break
+            case '.ts':
+                parserOpt = 'typescript'
+                break
+            case '.json':
+                parserOpt = 'json'
+                break
+            case '.gql':
+                parserOpt = 'graphql'
+                break
+            case '.md':
+                parserOpt = 'markdown'
+                break
+            case '.yaml':
+                parserOpt = 'yaml'
+                break
+            case '.js':
+                parserOpt = 'babel'
+                break
+            default:
+                parserOpt = false
+                break
         }
 
         // pretiffy output
@@ -803,20 +803,20 @@ export class PrismaAppSyncCompiler {
     // Return field sample for demo/docs
     private getFieldSample(field: DMMF.Field): any {
         switch (field.type) {
-        case 'Int':
-            return '2'
-        case 'String':
-            return '"Foo"'
-        case 'Json':
-            return { foo: 'bar' }
-        case 'Float':
-            return '2.5'
-        case 'Boolean':
-            return 'false'
-        case 'DateTime':
-            return '"dd/mm/YYYY"'
-        default:
-            return field.type
+            case 'Int':
+                return '2'
+            case 'String':
+                return '"Foo"'
+            case 'Json':
+                return { foo: 'bar' }
+            case 'Float':
+                return '2.5'
+            case 'Boolean':
+                return 'false'
+            case 'DateTime':
+                return '"dd/mm/YYYY"'
+            default:
+                return field.type
         }
     }
 
@@ -827,6 +827,7 @@ export class PrismaAppSyncCompiler {
 
     // Return relation kind (`one` or `many`) from Prisma type
     private getFieldRelationKind(field: DMMF.Field): 'one' | 'many' {
+        // return field.relationFromFields && field.relationFromFields.length === 1 ? 'one' : 'many'
         return !field.isList ? 'one' : 'many'
     }
 
@@ -836,34 +837,34 @@ export class PrismaAppSyncCompiler {
 
         if (field.kind === 'scalar' && typeof field.type === 'string') {
             switch (field.type.toLocaleLowerCase()) {
-            case 'int':
-                type = 'Int'
-                break
-            case 'datetime':
-                type = 'AWSDateTime'
-                break
-            case 'json':
-                type = 'AWSJSON'
-                break
-            case 'float':
-                type = 'Float'
-                break
-            case 'boolean':
-                type = 'Boolean'
-                break
-            case 'string':
-                type = 'String'
-                break
+                case 'int':
+                    type = 'Int'
+                    break
+                case 'datetime':
+                    type = 'AWSDateTime'
+                    break
+                case 'json':
+                    type = 'AWSJSON'
+                    break
+                case 'float':
+                    type = 'Float'
+                    break
+                case 'boolean':
+                    type = 'Boolean'
+                    break
+                case 'string':
+                    type = 'String'
+                    break
             }
 
             if (type === 'String') {
                 switch (field.name.toLocaleLowerCase()) {
-                case 'email':
-                    type = 'AWSEmail'
-                    break
-                case 'url':
-                    type = 'AWSURL'
-                    break
+                    case 'email':
+                        type = 'AWSEmail'
+                        break
+                    case 'url':
+                        type = 'AWSURL'
+                        break
                 }
             }
         }

--- a/packages/generator/templates/schema.gql.njk
+++ b/packages/generator/templates/schema.gql.njk
@@ -56,60 +56,6 @@ enum OrderByArg {
         every: {{ model.name }}WhereInput
         none: {{ model.name }}WhereInput
     }
-{# 
-    input {{ model.name }}RelationFilter {
-        {% for field in model.fields -%}
-            {% if not field.relation -%}
-                {% if field.isList -%}
-                    {% if field.isEnum -%}
-                        {{ field.name }}: {{ field.scalar }}EnumListFilter
-                    {% elseif field.scalar in ["Int", "Float", "AWSDateTime", "AWSJSON", "AWSEmail", "AWSURL", "Boolean"] -%}
-                        {{ field.name }}: {{ field.scalar }}ListFilter
-                    {% else -%}
-                        {{ field.name }}: StringListFilter
-                    {% endif -%}
-                {% else -%}
-                    {% if field.isEnum -%}
-                        {{ field.name }}: {{ field.scalar }}EnumFilter
-                    {% elseif field.scalar in ["Int", "Float", "AWSDateTime", "AWSJSON", "AWSEmail", "AWSURL", "Boolean"] -%}
-                        {{ field.name }}: {{ field.scalar }}Filter
-                    {% else -%}
-                        {{ field.name }}: StringFilter
-                    {% endif -%}
-                {% endif -%}
-            {% else -%}
-                {% if field.relation.kind === "one" -%}
-                    {{ field.name }}: {{ field.relation.type }}WhereInput
-                {% else  -%}
-                    {{ field.name }}: {{ field.relation.type }}Filter
-                {% endif -%}
-            {% endif -%}
-        {% endfor %}
-    } #}
-
-    {# input {{ model.name }}ScalarWhereInput {
-        {% for field in model.fields -%}
-            {% if not field.relation -%}
-                {% if field.isList -%}
-                    {% if field.isEnum -%}
-                        {{ field.name }}: {{ field.scalar }}EnumListFilter
-                    {% elseif field.scalar in ["Int", "Float", "AWSDateTime", "AWSJSON", "AWSEmail", "AWSURL", "Boolean"] -%}
-                        {{ field.name }}: {{ field.scalar }}ListFilter
-                    {% else -%}
-                        {{ field.name }}: StringListFilter
-                    {% endif -%}
-                {% else -%}
-                    {% if field.isEnum -%}
-                        {{ field.name }}: {{ field.scalar }}EnumFilter
-                    {% elseif field.scalar in ["Int", "Float", "AWSDateTime", "AWSJSON", "AWSEmail", "AWSURL", "Boolean"] -%}
-                        {{ field.name }}: {{ field.scalar }}Filter
-                    {% else -%}
-                        {{ field.name }}: StringFilter
-                    {% endif -%}
-                {% endif -%}
-            {% endif -%}
-        {% endfor %}
-    } #}
 
     input {{ model.name }}WhereInput {
         OR: [{{ model.name }}WhereInput]

--- a/packages/generator/templates/schema.gql.njk
+++ b/packages/generator/templates/schema.gql.njk
@@ -52,11 +52,11 @@ enum OrderByArg {
     {% endif %}
 
     input {{ model.name }}Filter {
-        some: {{ model.name }}ScalarWhereInput
-        every: {{ model.name }}ScalarWhereInput
-        none: {{ model.name }}ScalarWhereInput
+        some: {{ model.name }}WhereInput
+        every: {{ model.name }}WhereInput
+        none: {{ model.name }}WhereInput
     }
-
+{# 
     input {{ model.name }}RelationFilter {
         {% for field in model.fields -%}
             {% if not field.relation -%}
@@ -77,11 +77,17 @@ enum OrderByArg {
                         {{ field.name }}: StringFilter
                     {% endif -%}
                 {% endif -%}
+            {% else -%}
+                {% if field.relation.kind === "one" -%}
+                    {{ field.name }}: {{ field.relation.type }}WhereInput
+                {% else  -%}
+                    {{ field.name }}: {{ field.relation.type }}Filter
+                {% endif -%}
             {% endif -%}
         {% endfor %}
-    }
+    } #}
 
-    input {{ model.name }}ScalarWhereInput {
+    {# input {{ model.name }}ScalarWhereInput {
         {% for field in model.fields -%}
             {% if not field.relation -%}
                 {% if field.isList -%}
@@ -103,7 +109,7 @@ enum OrderByArg {
                 {% endif -%}
             {% endif -%}
         {% endfor %}
-    }
+    } #}
 
     input {{ model.name }}WhereInput {
         OR: [{{ model.name }}WhereInput]
@@ -130,7 +136,7 @@ enum OrderByArg {
                 {% endif -%}
             {% else -%}
                 {% if field.relation.kind === "one" -%}
-                    {{ field.name }}: {{ field.relation.type }}RelationFilter
+                    {{ field.name }}: {{ field.relation.type }}WhereInput
                 {% else  -%}
                     {{ field.name }}: {{ field.relation.type }}Filter
                 {% endif -%}

--- a/tests/generator/prisma-to-graphql.spec.ts
+++ b/tests/generator/prisma-to-graphql.spec.ts
@@ -118,7 +118,7 @@ describe('GENERATOR #gql', () => {
             `
             tester.test(true, query)
         })
-        test('expect "relation to one filter" query to be valid', async () => {
+        test('expect "relation to-one filter" query to be valid', async () => {
             const query = `
                 query {
                     listComments(
@@ -136,7 +136,7 @@ describe('GENERATOR #gql', () => {
             `
             tester.test(true, query)
         })
-        test('expect "relation to many filter" query to be valid', async () => {
+        test('expect "relation to-many filter" query to be valid', async () => {
             const query = `
                 query {
                     listUsers(
@@ -145,6 +145,92 @@ describe('GENERATOR #gql', () => {
                                 every: {
                                     published: {
                                         equals: true
+                                    }
+                                }
+                            }
+                        }
+                    ) {
+                        username
+                        email
+                        role
+                    }
+                }
+            `
+            tester.test(true, query)
+        })
+        test('expect "deeply nested relation to-one-to-many filter" query to be valid', async () => {
+            const query = `
+                query {
+                    listComments(
+                        where: {
+                            author: {
+                                posts: {
+                                    every: {
+                                        published: { equals: true }
+                                    }
+                                }
+                            }
+                        }
+                    ) {
+                        message
+                    }
+                }
+            `
+            tester.test(true, query)
+        })
+        test('expect "deeply nested relation to-many-to-many filter" query to be valid', async () => {
+            const query = `
+                query {
+                    listUsers(
+                        where: {
+                            posts: {
+                                every: {
+                                    comments: {
+                                        every: {
+                                            message: { startsWith: "hello" }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    ) {
+                        username
+                        email
+                        role
+                    }
+                }
+            `
+            tester.test(true, query)
+        })
+        test('expect "deeply nested relation to-one-to-one filter" query to be valid', async () => {
+            const query = `
+                query {
+                    listComments(
+                        where: {
+                            author: {
+                                profile: {
+                                    bio: { contains: "hello" }
+                                }
+                            }
+                        }
+                    ) {
+                        message
+                    }
+                }
+            `
+            tester.test(true, query)
+        })
+        test('expect "deeply nested relation to-many-to-one filter" query to be valid', async () => {
+            const query = `
+                query {
+                    listUsers(
+                        where: {
+                            posts: {
+                                every: {
+                                    author: {
+                                        username: {
+                                            equals: "username"
+                                        }
                                     }
                                 }
                             }

--- a/tests/prisma/schema.prisma
+++ b/tests/prisma/schema.prisma
@@ -28,7 +28,15 @@ model User {
   hiddenField String?
   role        Role?     @default(USER)
   posts       Post[]
+  profile     Profile?
   comments    Comment[]
+}
+
+model Profile {
+  uuid      String  @id @default(uuid()) @db.VarChar(200)
+  owner     User?   @relation(fields: [ownerUuid], references: [uuid])
+  ownerUuid String? @unique @db.VarChar(200)
+  bio       String?
 }
 
 /// @gql(model: null)


### PR DESCRIPTION
Fix WhereUniqueInput GraphQL input types to match Prisma's types 
Fix detection of relation kinds

I haven't tested everything thoroughly but it seemed to work from my testing. You gave me the go-ahead to make a pull request so feel free to play around with these changes!