### PR TITLE
fix: correct `UpdateRelationsInput` one-to-many delete & `deleteMany` input types

### DIFF
--- a/packages/generator/templates/schema.gql.njk
+++ b/packages/generator/templates/schema.gql.njk
@@ -234,18 +234,6 @@ enum NullArg {
             where: {{ model.name }}WhereUniqueInput!
             create: {{ model.name }}CreateInput!
         }
-
-        input {{ model.name }}DeleteUniqueInput {
-            {% if "extendedWhereUnique" in previewFeatures -%}
-                where: {{ model.name }}ExtendedWhereUniqueInput!
-            {% else  -%}
-                where: {{ model.name }}WhereUniqueInput!
-            {% endif -%}
-        }
-
-        input {{ model.name }}DeleteManyInput {
-            where: {{ model.name }}WhereInput!
-        }
     {% endif %}
 
     {% for field in model.fields -%}
@@ -277,15 +265,17 @@ enum NullArg {
                 connectOrCreate: [{{ field.relation.type }}ConnectOrCreateInput]
                 update: [{{ field.relation.type }}UpdateUniqueInput]
                 upsert: [{{ field.relation.type }}UpsertUniqueInput]
-                delete: [{{ field.relation.type }}DeleteUniqueInput]
                 {% if "extendedWhereUnique" in previewFeatures -%}
+                delete: [{{ field.relation.type }}ExtendedWhereUniqueInput]
                 disconnect: [{{ field.relation.type }}ExtendedWhereUniqueInput]
+                deleteMany: [{{ field.relation.type }}ExtendedWhereUniqueInput]
                 {% else  -%}
+                delete: [{{ field.relation.type }}WhereUniqueInput]
                 disconnect: [{{ field.relation.type }}WhereUniqueInput]
+                deleteMany: [{{ field.relation.type }}WhereUniqueInput]
                 {% endif -%}
                 set: [{{ field.relation.type }}WhereUniqueInput]
                 updateMany: [{{ field.relation.type }}UpdateManyInput]
-                deleteMany: [{{ field.relation.type }}DeleteManyInput]
                 {% endif -%}
             }
         {% endif -%}

--- a/packages/generator/templates/schema.gql.njk
+++ b/packages/generator/templates/schema.gql.njk
@@ -95,6 +95,33 @@ enum NullArg {
             {% endif -%}
         {% endfor %}
     }
+    
+    input {{ model.name }}ScalarWhereInput {
+        OR: [{{ model.name }}ScalarWhereInput]
+        NOT: [{{ model.name }}ScalarWhereInput]
+        AND: [{{ model.name }}ScalarWhereInput]
+        {% for field in model.fields -%}
+            {% if not field.relation -%}
+                {% if field.isList -%}
+                    {% if field.isEnum -%}
+                        {{ field.name }}: {{ field.scalar }}EnumListFilter
+                    {% elseif field.scalar in ["Int", "Float", "AWSDateTime", "AWSJSON", "AWSEmail", "AWSURL", "Boolean"] -%}
+                        {{ field.name }}: {{ field.scalar }}ListFilter
+                    {% else -%}
+                        {{ field.name }}: StringListFilter
+                    {% endif -%}
+                {% else -%}
+                    {% if field.isEnum -%}
+                        {{ field.name }}: {{ field.scalar }}EnumFilter
+                    {% elseif field.scalar in ["Int", "Float", "AWSDateTime", "AWSJSON", "AWSEmail", "AWSURL", "Boolean"] -%}
+                        {{ field.name }}: {{ field.scalar }}{% if not field.isRequired -%}Nullable{% endif -%}Filter
+                    {% else -%}
+                        {{ field.name }}: String{% if not field.isRequired -%}Nullable{% endif -%}Filter
+                    {% endif -%}
+                {% endif -%}
+            {% endif -%}
+        {% endfor %}
+    }
 
     input {{ model.name }}WhereUniqueInput {
         {% for field in model.fields -%}
@@ -211,7 +238,7 @@ enum NullArg {
         }
 
         input {{ model.name }}UpdateManyInput {
-            where: {{ model.name }}WhereInput!
+            where: {{ model.name }}ScalarWhereInput!
             data: {{ model.name }}UpdateInput!
         }
 
@@ -268,12 +295,11 @@ enum NullArg {
                 {% if "extendedWhereUnique" in previewFeatures -%}
                 delete: [{{ field.relation.type }}ExtendedWhereUniqueInput]
                 disconnect: [{{ field.relation.type }}ExtendedWhereUniqueInput]
-                deleteMany: [{{ field.relation.type }}ExtendedWhereUniqueInput]
                 {% else  -%}
                 delete: [{{ field.relation.type }}WhereUniqueInput]
                 disconnect: [{{ field.relation.type }}WhereUniqueInput]
-                deleteMany: [{{ field.relation.type }}WhereUniqueInput]
                 {% endif -%}
+                deleteMany: [{{ field.relation.type }}ScalarWhereInput]
                 set: [{{ field.relation.type }}WhereUniqueInput]
                 updateMany: [{{ field.relation.type }}UpdateManyInput]
                 {% endif -%}


### PR DESCRIPTION
Prisma only accepts `WhereUniqueInput` for those, no `where` required
I tested `delete` and it works good, haven't tried the `ExtendedWhereUniqueInput` with them or `deleteMany` but I assume it works just fine too

https://www.prisma.io/docs/reference/api-reference/prisma-client-reference#update-an-existing-user-record-by-deleting-two-post-records-its-connected-to