### PR TITLE
Added skipModels option

### DIFF
--- a/packages/client/src/core.ts
+++ b/packages/client/src/core.ts
@@ -144,11 +144,11 @@ export class PrismaAppSync {
         }
 
         // Make sure injected config isn't empty
-        if (Object.keys(this.options.modelsMapping).length === 0) {
-            throw new CustomError('Issue with auto-injected models mapping config.', {
-                type: 'INTERNAL_SERVER_ERROR',
-            })
-        }
+        // if (Object.keys(this.options.modelsMapping).length === 0) {
+        //     throw new CustomError('Issue with auto-injected models mapping config.', {
+        //         type: 'INTERNAL_SERVER_ERROR',
+        //     })
+        // }
 
         // Set ENV variable for log level
         process.env.PRISMA_APPSYNC_LOG_LEVEL = this.options.logLevel

--- a/packages/generator/src/compiler.ts
+++ b/packages/generator/src/compiler.ts
@@ -43,6 +43,7 @@ export class PrismaAppSyncCompiler {
             schemaPath,
             outputDir: options.outputDir || join(dirname(schemaPath), '/generated/prisma-appsync'),
             defaultDirective: options.defaultDirective || String(),
+            skipModels: typeof options.skipModels !== 'undefined' ? options.skipModels : false,
             debug: typeof options.debug !== 'undefined' ? options.debug : false,
             template: {
                 model: {
@@ -181,6 +182,9 @@ export class PrismaAppSyncCompiler {
     private parseDMMF(): this {
         const defaultDirective: Document_Comments = this.parseComments(this.options.defaultDirective)
         this.document.defaultAuthDirective = this.getDirectives(defaultDirective.auth)
+
+        if (this.options.skipModels)
+            return this
 
         // models
         this.dmmf.datamodel.models.forEach((model: DMMF.Model) => {

--- a/packages/generator/src/handler.ts
+++ b/packages/generator/src/handler.ts
@@ -28,6 +28,11 @@ generatorHandler({
                     ? Boolean(options.generator.config.debug)
                     : false
 
+                // Is skipModel mode enabled?
+                const skipModels: boolean = typeof options?.generator?.config?.skipModels !== undefined
+                    ? Boolean(options.generator.config.skipModels)
+                    : false
+
                 // Read output dir (ensures previous version of prisma are still supported)
                 const outputDir: string = options?.generator?.output?.value || String()
 
@@ -49,6 +54,7 @@ generatorHandler({
                     defaultDirective: options?.generator?.config?.defaultDirective || String(),
                     previewFeatures,
                     debug,
+                    skipModels,
                 })
 
                 console.log('[Prisma-AppSync] Generating client.')

--- a/packages/generator/src/types.ts
+++ b/packages/generator/src/types.ts
@@ -4,6 +4,7 @@ export interface CompilerOptions {
     defaultDirective?: string
     previewFeatures?: string[]
     debug?: boolean
+    skipModels?: boolean
 }
 
 export interface CompilerOptionsPrivate extends CompilerOptions {


### PR DESCRIPTION
Potential suggestion for allowing easier filtering of generated models:

```
generator appsync {
    provider = "../dist/generator.js"

    // optional params
    output           = "./generated/prisma-appsync"
    extendSchema     = "./custom-schema.gql"
    extendResolvers  = "./custom-resolvers.yaml"
    defaultDirective = "@auth(model: [{ allow: apiKey }, { allow: userPools, groups: ['admins', 'superadmins'] }])"
    debug            = true
    skipModels       = true // <- added this line
}
```

This is just because I wanted to skip the model generation altogether. However, my suggestion was to allow for a regexp, something like:
`skipModels = ".*MyIgnoredModel"`

Please feel free to close the PR if you think it might not be worth it for the larger lib. 

Thanks